### PR TITLE
frontend: apply consistent theme and responsive layout

### DIFF
--- a/frontend/src/components/AdminLogin.tsx
+++ b/frontend/src/components/AdminLogin.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react'
 import {
   Box,
-  Card,
-  CardContent,
   TextField,
   Button,
   Typography,
@@ -12,6 +10,8 @@ import {
 } from '@mui/material'
 import { AdminPanelSettings } from '@mui/icons-material'
 import { AuthLayout } from './AuthLayout'
+import { ResponsiveCard } from './ResponsiveCard'
+import { gradients } from '../theme'
 
 interface AdminLoginProps {
   onVerifyAdmin: (password: string) => void
@@ -46,8 +46,7 @@ export function AdminLogin({ onVerifyAdmin, onBack }: AdminLoginProps) {
       subtitle="Enter admin password to continue"
       onBack={onBack}
     >
-      <Card sx={{ border: 'none', boxShadow: 'none' }}>
-        <CardContent sx={{ p: isMobile ? 3 : 4 }}>
+      <ResponsiveCard>
           <Box sx={{ textAlign: 'center', mb: 3 }}>
             <Box
               sx={{
@@ -57,7 +56,7 @@ export function AdminLogin({ onVerifyAdmin, onBack }: AdminLoginProps) {
                 width: 64,
                 height: 64,
                 borderRadius: '50%',
-                background: 'linear-gradient(45deg, #9c27b0, #ce93d8)',
+                background: gradients.secondary,
                 mb: 2,
               }}
             >
@@ -113,19 +112,13 @@ export function AdminLogin({ onVerifyAdmin, onBack }: AdminLoginProps) {
             <Button
               fullWidth
               variant="contained"
+              color="secondary"
               onClick={handleVerify}
               disabled={!password || isLoading}
               sx={{
                 height: 56,
                 fontSize: isMobile ? '16px' : '1rem',
                 fontWeight: 600,
-                background: 'linear-gradient(45deg, #9c27b0 30%, #ce93d8 90%)',
-                '&:hover': {
-                  background: 'linear-gradient(45deg, #7b1fa2 30%, #9c27b0 90%)',
-                },
-                '&:disabled': {
-                  background: 'rgba(0, 0, 0, 0.12)',
-                },
               }}
               startIcon={
                 isLoading ? (
@@ -136,8 +129,7 @@ export function AdminLogin({ onVerifyAdmin, onBack }: AdminLoginProps) {
               {isLoading ? 'Checking...' : 'Sign in as Admin'}
             </Button>
           </Box>
-        </CardContent>
-      </Card>
+      </ResponsiveCard>
     </AuthLayout>
   )
 }

--- a/frontend/src/components/AuthLayout.tsx
+++ b/frontend/src/components/AuthLayout.tsx
@@ -1,14 +1,7 @@
-import { ReactNode } from 'react';
-import { 
-  Box, 
-  Container, 
-  Paper, 
-  useTheme, 
-  useMediaQuery,
-  IconButton,
-  Typography
-} from '@mui/material';
+import type { ReactNode } from 'react';
+import { Box, Container, Paper, IconButton, Typography } from '@mui/material';
 import { ArrowBack } from '@mui/icons-material';
+import { gradients } from '../theme';
 
 interface AuthLayoutProps {
   children: ReactNode;
@@ -18,21 +11,18 @@ interface AuthLayoutProps {
   showBackButton?: boolean;
 }
 
-export function AuthLayout({ 
-  children, 
-  title, 
-  subtitle, 
-  onBack, 
-  showBackButton = true 
+export function AuthLayout({
+  children,
+  title,
+  subtitle,
+  onBack,
+  showBackButton = true,
 }: AuthLayoutProps) {
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
-
   return (
     <Box
       sx={{
         minHeight: '100vh',
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        background: gradients.background,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
@@ -46,7 +36,7 @@ export function AuthLayout({
               onClick={onBack}
               sx={{
                 position: 'absolute',
-                left: isMobile ? -8 : 0,
+                left: { xs: -8, sm: 0 },
                 top: 0,
                 color: 'white',
                 backgroundColor: 'rgba(255, 255, 255, 0.1)',
@@ -58,8 +48,8 @@ export function AuthLayout({
               <ArrowBack />
             </IconButton>
           )}
-          
-          <Box sx={{ textAlign: 'center', pt: onBack && showBackButton && isMobile ? 6 : 0 }}>
+
+          <Box sx={{ textAlign: 'center', pt: onBack && showBackButton ? { xs: 6, sm: 0 } : 0 }}>
             <Typography
               variant="h4"
               component="h1"
@@ -67,7 +57,7 @@ export function AuthLayout({
                 color: 'white',
                 fontWeight: 700,
                 mb: 1,
-                fontSize: isMobile ? '2rem' : '2.5rem',
+                fontSize: { xs: '2rem', sm: '2.5rem' },
               }}
             >
               {title}
@@ -77,7 +67,7 @@ export function AuthLayout({
                 variant="body1"
                 sx={{
                   color: 'rgba(255, 255, 255, 0.8)',
-                  fontSize: isMobile ? '0.9rem' : '1rem',
+                  fontSize: { xs: '0.9rem', sm: '1rem' },
                 }}
               >
                 {subtitle}

--- a/frontend/src/components/AuthMethodSelector.tsx
+++ b/frontend/src/components/AuthMethodSelector.tsx
@@ -1,16 +1,8 @@
-import {
-  Box,
-  Card,
-  CardContent,
-  Button,
-  Typography,
-  Divider,
-  useTheme,
-  useMediaQuery,
-} from '@mui/material'
-import { Phone, Email, Security, AdminPanelSettings } from '@mui/icons-material'
+import { Box, Button, Typography, Divider, useTheme, useMediaQuery } from '@mui/material'
+import { Phone, Email, AdminPanelSettings } from '@mui/icons-material'
 import type { AuthMethod } from '../types/auth'
 import { AuthLayout } from './AuthLayout'
+import { ResponsiveCard } from './ResponsiveCard'
 
 interface AuthMethodSelectorProps {
   onSelectMethod: (method: AuthMethod) => void
@@ -26,8 +18,7 @@ export function AuthMethodSelector({ onSelectMethod }: AuthMethodSelectorProps) 
       subtitle="Select how you'd like to authenticate your account"
       showBackButton={false}
     >
-      <Card sx={{ border: 'none', boxShadow: 'none' }}>
-        <CardContent sx={{ p: isMobile ? 3 : 4 }}>
+      <ResponsiveCard>
           <Box sx={{ display: 'grid', gridTemplateColumns: '1fr', gap: 3 }}>
             <Box>
               <Button
@@ -38,15 +29,13 @@ export function AuthMethodSelector({ onSelectMethod }: AuthMethodSelectorProps) 
                   height: 80,
                   fontSize: isMobile ? '16px' : '18px',
                   fontWeight: 600,
-                  background: 'linear-gradient(45deg, #1976d2 30%, #42a5f5 90%)',
-                  '&:hover': {
-                    background: 'linear-gradient(45deg, #1565c0 30%, #1976d2 90%)',
-                    transform: 'translateY(-2px)',
-                  },
                   transition: 'all 0.2s ease-in-out',
                   display: 'flex',
                   flexDirection: 'column',
                   gap: 1,
+                  '&:hover': {
+                    transform: 'translateY(-2px)',
+                  },
                 }}
                 startIcon={<Phone sx={{ fontSize: '28px !important' }} />}
               >
@@ -192,8 +181,7 @@ export function AuthMethodSelector({ onSelectMethod }: AuthMethodSelectorProps) 
               Both methods are secure and use industry-standard encryption
             </Typography>
           </Box>
-        </CardContent>
-      </Card>
+      </ResponsiveCard>
     </AuthLayout>
   )
 }

--- a/frontend/src/components/EmailLogin.tsx
+++ b/frontend/src/components/EmailLogin.tsx
@@ -1,17 +1,9 @@
 import { useState } from 'react'
-import {
-  Box,
-  Card,
-  CardContent,
-  TextField,
-  Button,
-  Typography,
-  useTheme,
-  useMediaQuery,
-  CircularProgress,
-} from '@mui/material'
+import { Box, TextField, Button, Typography, CircularProgress } from '@mui/material'
 import { Email } from '@mui/icons-material'
 import { AuthLayout } from './AuthLayout'
+import { ResponsiveCard } from './ResponsiveCard'
+import { gradients } from '../theme'
 
 interface EmailLoginProps {
   onSendVerification: (email: string) => void
@@ -21,8 +13,6 @@ interface EmailLoginProps {
 export function EmailLogin({ onSendVerification, onBack }: EmailLoginProps) {
   const [email, setEmail] = useState('')
   const [isLoading, setIsLoading] = useState(false)
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   const handleSendVerification = async () => {
     if (!email || !isValidEmail(email)) return
@@ -52,8 +42,7 @@ export function EmailLogin({ onSendVerification, onBack }: EmailLoginProps) {
       subtitle="Enter your email to receive a verification code"
       onBack={onBack}
     >
-      <Card sx={{ border: 'none', boxShadow: 'none' }}>
-        <CardContent sx={{ p: isMobile ? 3 : 4 }}>
+      <ResponsiveCard>
           <Box sx={{ textAlign: 'center', mb: 3 }}>
             <Box
               sx={{
@@ -63,7 +52,7 @@ export function EmailLogin({ onSendVerification, onBack }: EmailLoginProps) {
                 width: 64,
                 height: 64,
                 borderRadius: '50%',
-                background: 'linear-gradient(45deg, #1976d2, #42a5f5)',
+                background: gradients.primary,
                 mb: 2,
               }}
             >
@@ -117,7 +106,7 @@ export function EmailLogin({ onSendVerification, onBack }: EmailLoginProps) {
               }}
               InputProps={{
                 sx: {
-                  fontSize: isMobile ? '16px' : '1rem',
+                  fontSize: { xs: '16px', sm: '1rem' },
                 },
               }}
             />
@@ -129,15 +118,8 @@ export function EmailLogin({ onSendVerification, onBack }: EmailLoginProps) {
               disabled={!email || !isValidEmail(email) || isLoading}
               sx={{
                 height: 56,
-                fontSize: isMobile ? '16px' : '1rem',
+                fontSize: { xs: '16px', sm: '1rem' },
                 fontWeight: 600,
-                background: 'linear-gradient(45deg, #1976d2 30%, #42a5f5 90%)',
-                '&:hover': {
-                  background: 'linear-gradient(45deg, #1565c0 30%, #1976d2 90%)',
-                },
-                '&:disabled': {
-                  background: 'rgba(0, 0, 0, 0.12)',
-                },
               }}
               startIcon={
                 isLoading ? (
@@ -161,8 +143,7 @@ export function EmailLogin({ onSendVerification, onBack }: EmailLoginProps) {
               Check your email inbox and spam folder for the verification code
             </Typography>
           </Box>
-        </CardContent>
-      </Card>
+      </ResponsiveCard>
     </AuthLayout>
   )
 }

--- a/frontend/src/components/EmailVerification.tsx
+++ b/frontend/src/components/EmailVerification.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react'
 import {
   Box,
-  Card,
-  CardContent,
   TextField,
   Button,
   Typography,
@@ -12,6 +10,8 @@ import {
 } from '@mui/material'
 import { MarkEmailRead } from '@mui/icons-material'
 import { AuthLayout } from './AuthLayout'
+import { ResponsiveCard } from './ResponsiveCard'
+import { gradients } from '../theme'
 
 interface EmailVerificationProps {
   email: string
@@ -57,8 +57,7 @@ export function EmailVerification({ email, onVerifyCode, onBack }: EmailVerifica
       subtitle="Enter the verification code we sent you"
       onBack={onBack}
     >
-      <Card sx={{ border: 'none', boxShadow: 'none' }}>
-        <CardContent sx={{ p: isMobile ? 3 : 4 }}>
+      <ResponsiveCard>
           <Box sx={{ textAlign: 'center', mb: 3 }}>
             <Box
               sx={{
@@ -68,7 +67,7 @@ export function EmailVerification({ email, onVerifyCode, onBack }: EmailVerifica
                 width: 64,
                 height: 64,
                 borderRadius: '50%',
-                background: 'linear-gradient(45deg, #1976d2, #42a5f5)',
+                background: gradients.primary,
                 mb: 2,
               }}
             >
@@ -155,13 +154,6 @@ export function EmailVerification({ email, onVerifyCode, onBack }: EmailVerifica
                   height: 56,
                   fontSize: isMobile ? '16px' : '1rem',
                   fontWeight: 600,
-                  background: 'linear-gradient(45deg, #1976d2 30%, #42a5f5 90%)',
-                  '&:hover': {
-                    background: 'linear-gradient(45deg, #1565c0 30%, #1976d2 90%)',
-                  },
-                  '&:disabled': {
-                    background: 'rgba(0, 0, 0, 0.12)',
-                  },
                 }}
                 startIcon={
                   isLoading ? (
@@ -215,8 +207,7 @@ export function EmailVerification({ email, onVerifyCode, onBack }: EmailVerifica
               </Button>
             </Box>
           </Box>
-        </CardContent>
-      </Card>
+      </ResponsiveCard>
     </AuthLayout>
   )
 }

--- a/frontend/src/components/LoginPage.tsx
+++ b/frontend/src/components/LoginPage.tsx
@@ -1,17 +1,9 @@
 import { useState } from 'react'
-import {
-  Box,
-  Card,
-  CardContent,
-  TextField,
-  Button,
-  Typography,
-  useTheme,
-  useMediaQuery,
-  CircularProgress,
-} from '@mui/material'
+import { Box, TextField, Button, Typography, CircularProgress } from '@mui/material'
 import { Phone } from '@mui/icons-material'
 import { AuthLayout } from './AuthLayout'
+import { ResponsiveCard } from './ResponsiveCard'
+import { gradients } from '../theme'
 
 interface LoginPageProps {
   onSendOTP: (phoneNumber: string) => void
@@ -21,8 +13,6 @@ interface LoginPageProps {
 export function LoginPage({ onSendOTP, onBack }: LoginPageProps) {
   const [phoneNumber, setPhoneNumber] = useState('')
   const [isLoading, setIsLoading] = useState(false)
-  const theme = useTheme()
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'))
 
   const handleSendOTP = async () => {
     if (!phoneNumber) return
@@ -41,8 +31,7 @@ export function LoginPage({ onSendOTP, onBack }: LoginPageProps) {
       subtitle="Sign in to continue to your account"
       onBack={onBack}
     >
-      <Card sx={{ border: 'none', boxShadow: 'none' }}>
-        <CardContent sx={{ p: isMobile ? 3 : 4 }}>
+      <ResponsiveCard>
           <Box sx={{ textAlign: 'center', mb: 3 }}>
             <Box
               sx={{
@@ -52,7 +41,7 @@ export function LoginPage({ onSendOTP, onBack }: LoginPageProps) {
                 width: 64,
                 height: 64,
                 borderRadius: '50%',
-                background: 'linear-gradient(45deg, #1976d2, #42a5f5)',
+                background: gradients.primary,
                 mb: 2,
               }}
             >
@@ -99,7 +88,7 @@ export function LoginPage({ onSendOTP, onBack }: LoginPageProps) {
               }}
               InputProps={{
                 sx: {
-                  fontSize: isMobile ? '16px' : '1rem',
+                  fontSize: { xs: '16px', sm: '1rem' },
                 },
               }}
             />
@@ -111,15 +100,8 @@ export function LoginPage({ onSendOTP, onBack }: LoginPageProps) {
               disabled={!phoneNumber || isLoading}
               sx={{
                 height: 56,
-                fontSize: isMobile ? '16px' : '1rem',
+                fontSize: { xs: '16px', sm: '1rem' },
                 fontWeight: 600,
-                background: 'linear-gradient(45deg, #1976d2 30%, #42a5f5 90%)',
-                '&:hover': {
-                  background: 'linear-gradient(45deg, #1565c0 30%, #1976d2 90%)',
-                },
-                '&:disabled': {
-                  background: 'rgba(0, 0, 0, 0.12)',
-                },
               }}
               startIcon={
                 isLoading ? (
@@ -130,8 +112,7 @@ export function LoginPage({ onSendOTP, onBack }: LoginPageProps) {
               {isLoading ? 'Sending...' : 'Send Verification Code'}
             </Button>
           </Box>
-        </CardContent>
-      </Card>
+      </ResponsiveCard>
     </AuthLayout>
   )
 }

--- a/frontend/src/components/MainPage.tsx
+++ b/frontend/src/components/MainPage.tsx
@@ -26,6 +26,7 @@ import {
   CheckCircle,
   Error,
 } from '@mui/icons-material'
+import { gradients } from '../theme'
 
 interface Location {
   latitude: number
@@ -73,7 +74,7 @@ export function MainPage({ onLogout, isAdmin = false }: MainPageProps) {
     <Box
       sx={{
         minHeight: '100vh',
-        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        background: gradients.background,
       }}
     >
       <AppBar

--- a/frontend/src/components/OTPVerification.tsx
+++ b/frontend/src/components/OTPVerification.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react'
 import {
   Box,
-  Card,
-  CardContent,
   TextField,
   Button,
   Typography,
@@ -12,6 +10,8 @@ import {
 } from '@mui/material'
 import { Shield } from '@mui/icons-material'
 import { AuthLayout } from './AuthLayout'
+import { ResponsiveCard } from './ResponsiveCard'
+import { gradients } from '../theme'
 
 interface OTPVerificationProps {
   phoneNumber: string
@@ -49,8 +49,7 @@ export function OTPVerification({ phoneNumber, onVerifyOTP, onBack }: OTPVerific
       subtitle="Enter the code sent to your phone"
       onBack={onBack}
     >
-      <Card sx={{ border: 'none', boxShadow: 'none' }}>
-        <CardContent sx={{ p: isMobile ? 3 : 4 }}>
+      <ResponsiveCard>
           <Box sx={{ textAlign: 'center', mb: 3 }}>
             <Box
               sx={{
@@ -60,7 +59,7 @@ export function OTPVerification({ phoneNumber, onVerifyOTP, onBack }: OTPVerific
                 width: 64,
                 height: 64,
                 borderRadius: '50%',
-                background: 'linear-gradient(45deg, #1976d2, #42a5f5)',
+                background: gradients.primary,
                 mb: 2,
               }}
             >
@@ -146,13 +145,6 @@ export function OTPVerification({ phoneNumber, onVerifyOTP, onBack }: OTPVerific
                   height: 56,
                   fontSize: isMobile ? '16px' : '1rem',
                   fontWeight: 600,
-                  background: 'linear-gradient(45deg, #1976d2 30%, #42a5f5 90%)',
-                  '&:hover': {
-                    background: 'linear-gradient(45deg, #1565c0 30%, #1976d2 90%)',
-                  },
-                  '&:disabled': {
-                    background: 'rgba(0, 0, 0, 0.12)',
-                  },
                 }}
                 startIcon={
                   isLoading ? (
@@ -206,8 +198,7 @@ export function OTPVerification({ phoneNumber, onVerifyOTP, onBack }: OTPVerific
               </Button>
             </Box>
           </Box>
-        </CardContent>
-      </Card>
+      </ResponsiveCard>
     </AuthLayout>
   )
 }

--- a/frontend/src/components/ResponsiveCard.tsx
+++ b/frontend/src/components/ResponsiveCard.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+import { Card, CardContent } from '@mui/material'
+
+interface ResponsiveCardProps {
+  children: ReactNode
+}
+
+export function ResponsiveCard({ children }: ResponsiveCardProps) {
+  return (
+    <Card sx={{ border: 'none', boxShadow: 'none' }}>
+      <CardContent sx={{ p: { xs: 3, sm: 4 } }}>{children}</CardContent>
+    </Card>
+  )
+}
+
+export default ResponsiveCard

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -1,4 +1,10 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme } from '@mui/material/styles'
+
+export const gradients = {
+  primary: 'linear-gradient(45deg, #1976d2 30%, #42a5f5 90%)',
+  secondary: 'linear-gradient(45deg, #9c27b0 30%, #ce93d8 90%)',
+  background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+}
 
 export const theme = createTheme({
   palette: {


### PR DESCRIPTION
## Summary
- centralize gradients and card spacing for a cleaner theme
- refactor auth screens to use responsive card component
- apply shared gradient background across layout and dashboard

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a73b908690832592582e55548391b8